### PR TITLE
Fix section stacking layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -196,6 +196,118 @@ svg.loading text{font-size:8vw}
 .volume input[type=range]::-webkit-slider-thumb{height:3vw!important;width:3vw!important;margin-top:-1.5vw!important}
 .volume input[type=range]::-webkit-slider-thumb:hover{filter:drop-shadow(0 0 .624vw rgba(255,255,255,.7))}
 }
+
+/* Nuevo concepto visual */
+:root{--midnight:#05040d;--wine:#2a0f2b;--sunset:#ff9156;--sky:#5ad2ff;--cloud:#f9f7f2;--glass:rgba(14,14,24,.75)}
+body{background:radial-gradient(circle at top,#1a0f2e 0%,#080611 45%,#05040d 100%);color:var(--cloud);overflow:auto}
+body.off{overflow:hidden}
+section{padding-bottom:0}
+main.layout section{height:auto;min-height:0;overflow:visible;background:transparent}
+.bg{filter:blur(40px);opacity:.35}
+.bg::after{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(255,145,86,.2),rgba(90,210,255,.1))}
+.layout{min-height:100vh;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:4vw;padding:6vw 6vw 8vw;position:relative;z-index:5}
+.hero{display:flex;flex-direction:column;gap:2vw}
+.logo-link{width:max-content}
+img.logo{position:relative;width:8vw;left:auto;top:auto;filter:drop-shadow(0 0 1.2vw rgba(255,255,255,.25))}
+.hero-copy{background:var(--glass);border-radius:2vw;padding:3vw;box-shadow:0 1.5vw 4vw rgba(0,0,0,.35);border:1px solid rgba(255,255,255,.08)}
+.hero-copy h1{color:var(--cloud);font-size:2.8vw;letter-spacing:-.05vw;margin:1vw 0 1.5vw}
+.hero-copy p{color:rgba(255,255,255,.78);font-size:1vw;line-height:1.8}
+.hero-copy p.lead{font-size:1.1vw}
+.hero-copy .eyebrow{font-size:.8vw;letter-spacing:.3vw;text-transform:uppercase;color:var(--sky);margin:0}
+.action-bar{display:flex;flex-wrap:wrap;gap:1vw;margin:2vw 0}
+.cent,.price{position:relative;left:auto;right:auto;top:auto;bottom:auto;z-index:auto}
+.cent a,.price a{font-size:1vw;padding:.9vw 1.6vw .9vw 3.4vw;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);color:var(--cloud);transition:all .2s}
+.cent a:hover,.price a:hover{background:rgba(255,255,255,.18);transform:translateY(-2px)}
+.cent a:before{background-image:url(../img/coin.gif)}
+.price a:before{background-image:url(../img/price.gif)}
+.made-with{font-size:.9vw;margin:1vw 0 0;color:rgba(255,255,255,.7)}
+.menu .made-with{margin:1vw 0 0}
+.player-card{background:rgba(6,6,16,.72);border-radius:2vw;padding:3vw;box-shadow:0 2vw 5vw rgba(0,0,0,.45);border:1px solid rgba(255,255,255,.08);display:flex;flex-direction:column;align-items:center;gap:2.5vw}
+.title{position:relative;left:auto;top:auto;transform:none;width:100%;height:auto;text-align:center}
+.title span.artist{font-size:.9vw;letter-spacing:.22vw}
+.title span.song{font-size:1.8vw;margin-top:.6vw}
+.cd{position:relative;width:26vw;height:26vw;left:auto;top:auto;transform:none;border-radius:1.6vw;background:linear-gradient(160deg,#140d2e,#2a0f2b)}
+.controls{position:relative;left:auto;bottom:auto;transform:none;width:100%;height:auto}
+.controls ul.cols.controls{position:relative;top:auto;left:auto;transform:none}
+.play{width:4.5vw!important;height:4.5vw!important;margin-right:1.5vw}
+.volume{width:30vw}
+.volume input[type=range]::-webkit-slider-runnable-track{background:linear-gradient(90deg,var(--sunset),var(--sky))}
+.volume input[type=range]::-webkit-slider-thumb{background:var(--cloud);border:.1vw solid rgba(255,255,255,.6)}
+.volume input[type=range]::-moz-range-track{background:linear-gradient(90deg,var(--sunset),var(--sky))}
+.eq{opacity:.15}
+footer{position:relative;padding:3vw 6vw 5vw;background:rgba(5,4,13,.8)}
+footer p{font-size:.9vw}
+.social{position:relative;bottom:auto;right:auto;margin-top:1.5vw}
+.social ul li a{border-color:rgba(255,255,255,.5)}
+.matchfm-sections{padding:2vw 6vw 6vw;background:linear-gradient(180deg,rgba(6,6,16,0) 0%,rgba(6,6,16,.7) 100%)}
+.section-header{text-align:center;max-width:60vw;margin:0 auto 3vw}
+.section-header h2{color:var(--cloud);font-size:2.2vw}
+.section-header p{color:rgba(255,255,255,.75);font-size:1.05vw}
+.platforms{margin:0 auto 3vw;text-align:center;display:flex;flex-direction:column;gap:1.6vw;align-items:center}
+.platforms p{margin:0;color:rgba(255,255,255,.7);font-size:1vw}
+.platform-logos{display:flex;gap:2.2vw;align-items:center;justify-content:center;flex-wrap:wrap}
+.platform-logos img{height:2.6vw;width:auto;filter:brightness(0) invert(1);opacity:.85;transition:all .2s}
+.platform-logos a:hover img{opacity:1;transform:translateY(-2px)}
+.station-url{font-family:"montserrat-bold";letter-spacing:.2vw;text-transform:uppercase;color:var(--sunset)}
+.section-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:2vw}
+.section-card{background:rgba(12,12,24,.75);border-radius:1.6vw;padding:2vw;border:1px solid rgba(255,255,255,.08);box-shadow:0 1vw 3vw rgba(0,0,0,.35);display:flex;flex-direction:column;gap:1vw}
+.section-card h3{color:var(--cloud);font-size:1.4vw;margin:0}
+.section-card p{color:rgba(255,255,255,.72);font-size:.95vw;margin:0}
+.section-card a{color:var(--sky);font-size:.9vw;text-decoration:none;font-family:"montserrat-bold";letter-spacing:.08vw;text-transform:uppercase}
+.section-card a:hover{color:var(--sunset)}
+.community-section{padding:0 6vw 6vw;background:rgba(6,6,16,.7)}
+.community-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2vw;margin-top:2vw}
+.community-card{background:rgba(12,12,24,.78);border-radius:1.6vw;padding:2.4vw;border:1px solid rgba(255,255,255,.08);box-shadow:0 1vw 3vw rgba(0,0,0,.35);display:flex;flex-direction:column;gap:1vw}
+.community-card h3{color:var(--cloud);font-size:1.5vw;margin:0}
+.community-card p{color:rgba(255,255,255,.72);font-size:1vw;margin:0}
+.community-metric{font-family:"montserrat-bold";font-size:2.2vw;color:var(--sunset)}
+.request-form{display:flex;flex-direction:column;gap:1vw}
+.request-form label{display:flex;flex-direction:column;gap:.5vw;color:rgba(255,255,255,.7);font-size:.9vw}
+.request-form input,.request-form textarea{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);border-radius:.8vw;padding:.8vw;color:var(--cloud);font-family:"montserrat-light"}
+.request-form textarea{resize:vertical;min-height:6vw}
+.request-form button{align-self:flex-start;background:var(--sunset);color:#111;border-radius:100px;padding:.8vw 2vw;font-family:"montserrat-bold";text-transform:uppercase;letter-spacing:.1vw;cursor:pointer;transition:all .2s}
+.request-form button:hover{filter:drop-shadow(0 0 .4vw rgba(255,145,86,.6))}
+
+@media only screen and (max-width:1024px){
+.layout{grid-template-columns:1fr;padding:10vw 6vw 12vw}
+img.logo{width:16vw}
+.hero-copy h1{font-size:6vw}
+.hero-copy p,.hero-copy p.lead{font-size:3vw}
+.hero-copy .eyebrow{font-size:2vw}
+.cent a,.price a{font-size:3vw;padding:2vw 3vw 2vw 10vw}
+.cent a:before,.price a:before{width:7vw;height:7vw}
+.player-card{padding:6vw;border-radius:4vw}
+.title span.song{font-size:4.5vw}
+.title span.artist{font-size:2.3vw}
+.cd{width:60vw;height:60vw;border-radius:4vw}
+.play{width:12vw!important;height:12vw!important}
+.volume{width:60vw}
+footer p,.made-with{font-size:2.4vw}
+.social ul li a{width:12vw!important;height:12vw!important}
+.matchfm-sections{padding:6vw 6vw 10vw}
+.section-header{max-width:100%;margin-bottom:5vw}
+.section-header h2{font-size:5vw}
+.section-header p{font-size:2.8vw}
+.platforms{gap:3vw}
+.platforms p{font-size:2.6vw}
+.platform-logos img{height:6.2vw}
+.station-url{font-size:2.8vw}
+.section-grid{grid-template-columns:1fr;gap:4vw}
+.section-card{border-radius:4vw;padding:5vw}
+.section-card h3{font-size:3.8vw}
+.section-card p{font-size:2.6vw}
+.section-card a{font-size:2.4vw}
+.community-section{padding:0 6vw 10vw}
+.community-grid{grid-template-columns:1fr;gap:4vw}
+.community-card{border-radius:4vw;padding:5vw}
+.community-card h3{font-size:3.8vw}
+.community-card p{font-size:2.6vw}
+.community-metric{font-size:6vw}
+.request-form label{font-size:2.4vw}
+.request-form input,.request-form textarea{border-radius:2.6vw;padding:2.4vw;font-size:2.4vw}
+.request-form textarea{min-height:20vw}
+.request-form button{padding:2.4vw 6vw;font-size:2.4vw}
+}
 @media only screen and (max-device-width:1024px) and (max-device-height:1366px) and (orientation:portrait){img.logo{width:15vw}
 .title{font-size:4vw;width:70vw}
 .title span.artist{font-size:2vw}

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 <a href="comingsoom" target="_blank"><img  src="https://lirp.cdn-website.com/b6481524/dms3rep/multi/opt/e+medios+opuesto-154w.png" alt="PROGRAMAS"/></a>
 </div>
 <p><b>© RADIO AVENTURA</b> La mejor radio en vivo</p>
+<p class="made-with">Hecho con amor por estacionkusmedios.</p>
 <div class="social">
 <ul>
 <li><a href="https://www.facebook.com/radioaventurajoven" target="facebook" rel="nofollow"><img src="img/facebook.svg"></a></li>
@@ -48,8 +49,25 @@
 </nav>
 
 
-<section>
-<a href="./"><img class="logo" src="img/logo.png" alt="Player para Radio Aventura"/></a>
+<div class="bg"><img class="lazyload" src="img/default.jpg" alt=""/></div>
+<div class="eq"><img class="lazyload" src="img/eq.svg" alt=""/></div>
+
+<main class="layout">
+<header class="hero">
+<a href="./" class="logo-link"><img class="logo" src="img/logo.png" alt="Player para Radio Aventura"/></a>
+<div class="hero-copy">
+<p class="eyebrow">Radio Aventura en vivo</p>
+<h1>Un concepto original para sentir cada ritmo.</h1>
+<p class="lead">Una experiencia más cálida, clara y vibrante: música, comunidad y energía en un mismo lugar.</p>
+<div class="action-bar">
+<div class="cent"><a href="https://paypal.me/ekusmedios" target="_blank" rel="nofollow">Donar</a></div>
+<div class="price"><a href="#">Publicidad</a></div>
+</div>
+<p class="made-with">Hecho con amor por estacionkusmedios.</p>
+</div>
+</header>
+
+<section class="player-card">
 <div class="title">
 <div class="placeholder">
 <span class="artist">Artista</span>
@@ -58,7 +76,6 @@
 </div>
 
 <div class="cd"><div class="images"><img class="lazyload" src="img/default.jpg" alt="cover o portada"/></div></div>
-<div class="cent"><a href="https://paypal.me/ekusmedios" target="_blank" rel="nofollow">Donar</a></div>
 
 <div class="controls">
 <ul class="cols controls">
@@ -80,23 +97,98 @@
 </li>
 </ul>
 </div>
-
-<div class="bg"><img class="lazyload" src="img/default.jpg" alt=""/></div>
-<div class="eq"><img class="lazyload" src="img/eq.svg" alt=""/></div>
 </section>
-
-
-
-
-
+<section class="matchfm-sections">
+<div class="section-header">
+<h2>Vive la experiencia Radio Aventura</h2>
+<p>Inspirado en emisoras actuales: programación dinámica, comunidad activa y contenido fresco cada día.</p>
+</div>
+<div class="platforms">
+<p>Escúchanos también en:</p>
+<div class="platform-logos">
+<a href="https://tunein.com" target="_blank" rel="nofollow">
+<img src="https://upload.wikimedia.org/wikipedia/commons/0/0a/TuneIn_Logo_2015.svg" alt="TuneIn"/>
+</a>
+<a href="https://www.radioline.co" target="_blank" rel="nofollow">
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/3d/Radioline_logo.svg" alt="Radioline"/>
+</a>
+</div>
+<p class="station-url">radioaventuramx</p>
+</div>
+<div class="section-grid">
+<article class="section-card">
+<h3>Programas destacados</h3>
+<p>Selección curada de shows en vivo, entrevistas y especiales para cada momento.</p>
+<a href="comingsoom">Ver programación</a>
+</article>
+<article class="section-card">
+<h3>Top Hits Aventura</h3>
+<p>Rotación de éxitos actuales con el sello único de la estación.</p>
+<a href="#">Escuchar ranking</a>
+</article>
+<article class="section-card">
+<h3>Noticias & Cultura Pop</h3>
+<p>Lo último en música, tendencias y movimientos culturales.</p>
+<a href="#">Ir a noticias</a>
+</article>
+<article class="section-card">
+<h3>Eventos & Comunidad</h3>
+<p>Conexión directa con eventos locales, lives y activaciones.</p>
+<a href="#">Ver agenda</a>
+</article>
+<article class="section-card">
+<h3>App & Reproducción</h3>
+<p>Escucha en cualquier lugar, descárgala y mantente conectado.</p>
+<a href="https://estacionkusmedios.org" target="_blank">Descargar app</a>
+</article>
+<article class="section-card">
+<h3>Contacto rápido</h3>
+<p>Publicidad, colaboraciones o saludos al aire.</p>
+<a href="https://wa.me/4622461396" target="_blank" rel="nofollow">Escríbenos</a>
+</article>
+</div>
+</section>
+<section class="community-section">
+<div class="section-header">
+<h2>Comunidad en vivo</h2>
+<p>Participa con la estación: revisa oyentes conectados y envía tus peticiones musicales.</p>
+</div>
+<div class="community-grid">
+<article class="community-card">
+<h3>Oyentes en vivo</h3>
+<p class="community-metric"><span id="listeners-count">—</span> conectados</p>
+<p>Actualizado en tiempo real desde la señal en streaming.</p>
+</article>
+<article class="community-card">
+<h3>Peticiones musicales</h3>
+<p>Envía tu canción favorita y tu saludo. Llegará directo a la producción.</p>
+<form class="request-form" action="mailto:cushmediagroup@gmail.com" method="post" enctype="text/plain">
+<label>
+<span>Nombre</span>
+<input type="text" name="nombre" placeholder="Tu nombre" required>
+</label>
+<label>
+<span>Correo</span>
+<input type="email" name="correo" placeholder="tu@email.com" required>
+</label>
+<label>
+<span>Petición</span>
+<textarea name="peticion" rows="4" placeholder="Artista - Canción y mensaje" required></textarea>
+</label>
+<button type="submit">Enviar petición</button>
+</form>
+</article>
+</div>
+</section>
+</main>
 
 <footer>
-<div class="price"><a href="#">Publicidad</a></div>
 <div class="app">
 <a href="https://estacionkusmedios.org" target="_blank"><img src="https://lirp.cdn-website.com/b6481524/dms3rep/multi/opt/e+medios+opuesto-154w.png" alt="Descarga la aplicacion para iPhone"/></a>
 <a href="comingsoom" target="_blank"><img  src="https://lirp.cdn-website.com/b6481524/dms3rep/multi/opt/e+medios+opuesto-154w.png" alt="PROGRAMAS"/></a>
 </div>
 <p><b>© RADIO AVENTURA</b> La mejor radio en vivo</p>
+<p class="made-with">Hecho con amor por estacionkusmedios.</p>
 <div class="social">
 <ul>
 <li><a href="https://www.facebook.com/radioaventurajoven" target="facebook" rel="nofollow"><img src="img/facebook.svg"></a></li>
@@ -143,14 +235,34 @@ const [artist, song] = currentSong.split(" - ");
 $(".artist").shuffleLetters({text:artist, fps:20});
 $(".song").shuffleLetters({text:song, fps:30});
 document.title = currentSong;
+const listeners = data.listeners_current ?? data.listeners ?? data.listenersCount ?? data.listeners_count;
+if (listeners !== undefined && listeners !== null) {
+$("#listeners-count").text(listeners);
+}
 
 $.getJSON(`https://itunes.apple.com/search?term==${artist.replace(/\W+/g, '+')}&media=music&limit=1`, 
 coverData => {
-const image = coverData.results[0]?.artworkUrl100.replace("100x100bb", "600x600bb") || "img/default.jpg";
-$(".images").append(`<img src="${image}" class="lazyload" alt="${currentSong}" />`).find(".lazyload").on("lazyloaded", function () { $(".bg img").remove();
-$(".bg").append(`<img src="${image}" class="lazyload" alt="" />`);
+const artwork = coverData.results?.[0]?.artworkUrl100;
+const image = artwork ? artwork.replace("100x100bb", "600x600bb") : "img/default.jpg";
+const $newCover = $(`<img src="${image}" class="lazyload" alt="${currentSong}" />`);
+
+const updateCover = () => {
+const $bg = $(".bg");
+const $bgImage = $(`<img src="${image}" class="lazyload" alt="" />`);
+$bg.append($bgImage);
+$bg.find("img").not($bgImage).remove();
 $(".images").css({ transition: "all 1s", transform: "translateX(-100%)" });
-setTimeout(() => $(".images").removeAttr("style").find("img:first-child").remove(), 1500)});
+setTimeout(() => $(".images").removeAttr("style").find("img:first-child").remove(), 1500);
+};
+
+$newCover.on("load lazyloaded", updateCover);
+$newCover.on("error", function () {
+if (image !== "img/default.jpg") {
+$(this).attr("src", "img/default.jpg");
+}
+});
+
+$(".images").append($newCover);
 });
 
 });

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -1,0 +1,17 @@
+# Instrucciones
+
+## Cambios realizados en esta versión
+- Se corrigió el estilo base de `<section>` para que las secciones dentro de `main` se apilen y no se oculten.
+- Ajuste de estilos para garantizar que MatchFM, plataformas y comunidad se vean completas en web y móvil.
+
+## Requisitos o dependencias nuevas
+- Ninguno.
+
+## Guía paso a paso para probar la funcionalidad
+1. Ejecuta un servidor local:
+   - `python -m http.server 8000`
+2. Abre el navegador en:
+   - `http://localhost:8000`
+3. Verifica:
+   - Que las secciones "Vive la experiencia", plataformas y comunidad se muestren completas.
+   - Que en móvil el contenido se apile sin solaparse.


### PR DESCRIPTION
### Motivation
- Corregir un problema de presentación donde las secciones dentro de `main` quedaban ocultas/solapadas tras el último merge para que las áreas (MatchFM, plataformas y comunidad) se muestren completas en desktop y móvil.

### Description
- Añadida la regla CSS `main.layout section{height:auto;min-height:0;overflow:visible;background:transparent}` en `css/main.css` y creación de `instrucciones.md` que documenta los cambios y pasos para vista previa.

### Testing
- Se lanzó un servidor local con `python -m http.server 8000` y se ejecutó un script Playwright que cargó `http://127.0.0.1:8000` y generó un pantallazo de referencia en `browser:/tmp/codex_browser_invocations/87e1127b6d4adcb9/artifacts/artifacts/radioaventura-sections-fixed.png`, ambos pasos completados con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f1e2a5ec83219c93fc1df76f0994)